### PR TITLE
Set the name of the app

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -45,6 +45,7 @@ const createWindow = async () => {
   })
 }
 app.commandLine.appendSwitch('disable-http-cache')
+app.setName('tithon')
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()


### PR DESCRIPTION
This makes electron set WM_CLASS to something more useful than "electron".