### PR TITLE
Fix double space in actions.

### DIFF
--- a/backend/irc/message.go
+++ b/backend/irc/message.go
@@ -114,6 +114,7 @@ func (m *Message) parseAction() {
 	if strings.HasPrefix(m.message, "\001ACTION") && strings.HasSuffix(m.message, "\001") {
 		m.message = strings.TrimPrefix(m.message, "\001ACTION")
 		m.message = strings.TrimSuffix(m.message, "\001")
+		m.message = strings.TrimSpace(m.message)
 		m.messageType = Action
 	}
 }


### PR DESCRIPTION
Receiving a message like \001ACTION slaps\001 resulted in the action having a content of " slaps". It then gets a second space added to it later when displayed.

Trim incoming actions to fix this.